### PR TITLE
Fix for display of login instructions

### DIFF
--- a/src/partials/p_home.php
+++ b/src/partials/p_home.php
@@ -221,10 +221,12 @@ class Home_Partial {
         if (($site = $user->conf->opt("conferenceSite"))
             && $site !== $user->conf->opt("paperSite"))
             echo " For general conference information, see ", Ht::link(htmlspecialchars($site), htmlspecialchars($site)), ".";
-        echo ' <p class="login_instructions">This site is built using the HotCRP conference review software. ',
-             'You need to <a href="',
-              $user->conf->hoturl("newaccount"),
-              '" class="uic js-href-add-email">Create an account</a> with your email address for every conference.</p>';
+        if (!$user->is_signed_in()) {
+          echo ' <p class="login_instructions">This site is built using the HotCRP conference review software. ',
+               'You need to <a href="',
+                $user->conf->hoturl("newaccount"),
+                '" class="uic js-href-add-email">Create an account</a> with your email address for every conference.</p>';
+        }
         echo '</div>';
     }
 


### PR DESCRIPTION
This was filed as an [issue](https://github.com/IACR/submit-server/issues/25). The fix is pretty simple - only show the instructions if someone is not signed in. @cca88 reviewed the previous version.