### PR TITLE
First cut at creating final version upload links.

### DIFF
--- a/iacr/includes/papertable.php
+++ b/iacr/includes/papertable.php
@@ -1,0 +1,30 @@
+<?php
+// This is included from src/papertable.php.
+
+function echo_iacr_final_upload(DocumentPaperOption $docx, $paper) {
+  include_once("/var/www/util/hotcrp/hmac.php");
+  $paper_msg = get_paper_message($docx->conf->opt["iacrType"],
+                                 $docx->conf->opt["year"],
+                                 $paper->paperId,
+                                 $Me->email,
+                                 $docx->conf->opt["shortName"]);
+  $querydata = array("venue" => $docx->conf->opt["iacrType"],
+                     "year" => $docx->conf->opt["year"],
+                     "paperId" => $paper->paperId,
+                     "email" => $Me->email,
+                     "shortName" => $docx->conf->opt["shortName"],
+                     "auth" => get_hmac($paper_msg));
+  $url = "https://iacr.org/submit/upload/paper.php?" . http_build_query($querydata);
+  $extras = array("class" => "iacrSubmitButtons");
+  echo Ht::link("Upload final paper", $url, $extras);
+  $url = "https://iacr.org/submit/upload/slides.php?" . http_build_query($querydata);
+  echo Ht::link("Upload slides", $url, $extras);
+}
+
+function echo_iacrcopyright_button($paperId, $shortName) {
+  $extras = array("class" => "iacrSubmitButtons");
+  $url = "/$shortName/iacrcopyright/" . strval($paperId);
+  echo Ht::link("IACR copyright form", $url, $extras);
+}
+
+?>

--- a/scripts/iacr.js
+++ b/scripts/iacr.js
@@ -1,0 +1,30 @@
+/* 
+ *  A checkbox in HotCRP has a label that is also clickable. We want to make
+ *  the checkbox unclickable, so we also have to remove the js-click-child
+ *  class from the label of the checkbox.
+ */
+function removeClickEventOnCheckbox(id) {
+  let cb = document.getElementById(id);
+  if (!cb) {
+    console.log('missing checkbox for ' + id);
+    return;
+  }
+  // This will make the label unclickable.
+  cb.parentNode.parentNode.parentNode.classList.remove('js-click-child');
+  // This makes the checkbox unclickable. We can't make it disabled
+  // because then it isn't submitted.
+  cb.addEventListener('click', function(event) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    return true;
+  });
+}
+
+/*
+ *  This is used on the paper submission form.
+ */
+function iacrSubmitAndUploadCheckboxes() {
+  removeClickEventOnCheckbox('iacr-copyright-agreement');
+  removeClickEventOnCheckbox('upload-final-paper');
+}
+

--- a/src/papertable.php
+++ b/src/papertable.php
@@ -2,6 +2,13 @@
 // papertable.php -- HotCRP helper class for producing paper tables
 // Copyright (c) 2006-2020 Eddie Kohler; see LICENSE.
 
+///////////// Added for IACR functionality ////////////
+global $ConfSitePATH, $Opt;
+if (isset($Opt["iacrType"])) {
+  include "$ConfSitePATH/iacr/includes/papertable.php";
+}
+///////////////////////////////////////////////////////
+
 class PaperTable {
     public $conf;
     public $prow;
@@ -660,6 +667,11 @@ class PaperTable {
                 || $noPapers === true
                 || ($dtype == DTYPE_FINAL) !== $this->canUploadFinal)
                 return;
+        }
+        if (isset($docx->conf->opt["iacrType"]) && $dtype === DTYPE_FINAL) {
+          echo_iacr_final_upload($docx, $this->prow);
+          echo "</div>";
+          return;
         }
         $inputid = $dtype > 0 ? "opt" . $dtype : "paperUpload";
 
@@ -1532,13 +1544,14 @@ class PaperTable {
     }
 
     function echo_editable_option_papt(PaperOption $o, $heading = null, $rest = []) {
+        global $Opt;
         if (!$heading) {
             $heading = $this->edit_title_html($o);
         }
-        $this->echo_editable_papt($o->formid, $heading, $rest, $o);
         if ($o !== null && $o->readable_formid() === "iacr-copyright-agreement") {
-            echo "<strong><a href=\"../../iacrcopyright/" . $this->prow->paperId  . "\">IACR copyright form</a></strong>";
+            echo_iacrcopyright_button($this->prow->paperId, $Opt["shortName"]);
         }
+        $this->echo_editable_papt($o->formid, $heading, $rest, $o);
         $this->echo_field_hint($o);
         echo Ht::hidden("has_{$o->formid}", 1);
     }
@@ -2394,6 +2407,14 @@ class PaperTable {
         }
 
         echo "</div></form>";
+
+        // This is to disable the IACR checkboxes on the submission form for
+        // a paper. We control those separately when an appropriate action is
+        // completed.
+        if (array_key_exists("iacrType", $this->conf->opt)) {
+          Ht::stash_script("iacrSubmitAndUploadCheckboxes()");
+        }
+
         $this->user->set_overrides($overrides);
     }
 

--- a/src/settings/s_options.php
+++ b/src/settings/s_options.php
@@ -192,6 +192,16 @@ class Options_SettingRenderer {
 
     static function render(SettingValues $sv) {
         echo "<h3 class=\"form-h\">Submission fields</h3>\n";
+        global $Opt;
+        if (isset($Opt["iacrType"])) {
+          echo "<div class=\"msg msg-error\">Warning: do not change the fields for final versions and copyright. IACR handles them differently from HotCRP.";
+          if ($Opt["iacrType"] !== "tosc" &&
+              $Opt["iacrType"] !== "tches" &&
+              $Opt["iacrType"] !== "rump") {
+             echo " Accepted papers will also have an option to upload slides to the IACR server.";
+          }
+          echo "</div>";
+        }
         echo "<hr class=\"g\">\n",
             Ht::hidden("has_options", 1), "\n\n";
 

--- a/stylesheets/iacr.css
+++ b/stylesheets/iacr.css
@@ -147,3 +147,20 @@ select#iacrvenue {
 button#fetchIACR {
   margin-left: 0.8rem;
 }
+
+/* buttons for submitting final paper and slides. */
+a.iacrSubmitButtons {
+  border-radius: 4px;
+  margin: .0 2rem .5rem 0rem;
+  background-color: #17a2b8;
+  border-color: #17a2b8;
+  color: white;
+  padding: .4em;
+  text-decoration: none;
+  display: inline-block;
+}
+
+a.iacrSubmitButtons:hover {
+  background-color: #138496;
+  border-color: #117a8b;
+}


### PR DESCRIPTION
This has a companion pull request on IACR/submit-server to set the configuration correctly. It adds links (buttons) to upload a paper, sign the copyright form, and upload slides. I expect the slides link to change since this breaks setup for rump sessions.