### PR TITLE
This makes the IACR options required.

### DIFF
--- a/iacr/includes/papertable.php
+++ b/iacr/includes/papertable.php
@@ -1,34 +1,74 @@
 <?php
-// This is included from src/papertable.php.
+// This is included from src/papertable.php. and src/settings/s_options.php
+// It is intended for handling of special IACR paper options in the submission
+// form. These are created by create_conf.py, and have an id as follows:
+//
+// 5: copyright     (required for authors, may not be deleted)
+// 6: upload paper  (required for authors, may not be deleted)
+// 7: upload slides (optional for authors, may not be deleted)
+// 8: upload video. (optional for authors, may be deleted)
 
-function echo_iacr_final_upload(DocumentPaperOption $docx, $paper, $email) {
-  include_once('/var/www/util/hotcrp/hmac.php');
-  $paper_msg = get_paper_message($docx->conf->opt['iacrType'],
-                                 $docx->conf->opt['year'],
-                                 $paper->paperId,
-                                 $email,
-                                 'hc',
-                                 $docx->conf->opt['shortName']);
-  $querydata = array('venue' => $docx->conf->opt['iacrType'],
-                     'year' => $docx->conf->opt['year'],
-                     'paperId' => $paper->paperId,
-                     'email' => $email,
-                     'shortName' => $docx->conf->opt['shortName'],
-                     'auth' => get_hmac($paper_msg),
-                     'app' => 'hc');
-  $url = 'https://iacr.org/submit/upload/paper.php?' . http_build_query($querydata);
-  $extras = array('class' => 'iacrSubmitButtons');
-  echo Ht::link('Upload final paper', $url, $extras);
-  $url = 'https://iacr.org/submit/upload/slides.php?' . http_build_query($querydata);
-  echo Ht::link('Upload slides', $url, $extras);
-  $url = 'https://iacr.org/submit/upload/video.php?' . http_build_query($querydata);
-  echo Ht::link('Upload video', $url, $extras);
+/**
+ * Called with a PaperOption to determine if it requires special
+ * handling. If the chair deletes the video option, then ID 8 might be
+ * replaced by something with a new name, so we check for that.
+ */
+function iacr_paper_option(PaperOption $opt) {
+   return iacr_required_paper_option($opt->id) ||
+          ($opt->id == 8 && $opt->name == "Upload video");
 }
 
-function echo_iacrcopyright_button($paperId, $shortName) {
+/**
+ * These options may not be deleted by the administrator. The slides
+ * option is not mandantory for authors.
+ */
+function iacr_required_paper_option($val) {
+  return ($val == 5 || $val === 6 || $val == 7);
+}
+
+/**
+ * Used to echo a button. $val should be one of 5, 6, 7, 8 (the IDs
+ * of the relevant PaperOption).
+*/
+function echo_iacr_button($val, Conf $conf, $paperId) {
+  global $Me;
+  $email = $Me->email;
+  include_once('/var/www/util/hotcrp/hmac.php');
+  $paper_msg = get_paper_message($conf->opt['iacrType'],
+                                 $conf->opt['year'],
+                                 $paperId,
+                                 $email,
+                                 'hc',
+                                 $conf->opt['shortName']);
+  $querydata = array('venue' => $conf->opt['iacrType'],
+                     'year' => $conf->opt['year'],
+                     'paperId' => $paperId,
+                     'email' => $email,
+                     'shortName' => $conf->opt['shortName'],
+                     'auth' => get_hmac($paper_msg),
+                     'app' => 'hc');
+  switch($val) {
+    case 5:
+      $url = '/' . $conf->opt['shortName'] . '/iacrcopyright/' . strval($paperId);
+      $msg = 'IACR copyright form';
+      break;
+    case 6:
+      $url = 'https://iacr.org/submit/upload/paper.php?' . http_build_query($querydata);
+      $msg = 'Upload final paper';
+      break;
+    case 7:
+      $url = 'https://iacr.org/submit/upload/slides.php?' . http_build_query($querydata);
+      $msg = 'Upload slides';
+      break;
+    case 8:
+      $url = 'https://iacr.org/submit/upload/video.php?' . http_build_query($querydata);
+      $msg = 'Upload video';
+      break;
+    default:
+      return;
+  }
   $extras = array('class' => 'iacrSubmitButtons');
-  $url = '/$shortName/iacrcopyright/' . strval($paperId);
-  echo Ht::link('IACR copyright form', $url, $extras);
+  echo Ht::link($msg, $url, $extras);
 }
 
 ?>

--- a/scripts/iacr.js
+++ b/scripts/iacr.js
@@ -26,5 +26,7 @@ function removeClickEventOnCheckbox(id) {
 function iacrSubmitAndUploadCheckboxes() {
   removeClickEventOnCheckbox('iacr-copyright-agreement');
   removeClickEventOnCheckbox('upload-final-paper');
+  removeClickEventOnCheckbox('upload-slides');
+  removeClickEventOnCheckbox('upload-video');
 }
 

--- a/src/paperoption.php
+++ b/src/paperoption.php
@@ -2,6 +2,11 @@
 // paperoption.php -- HotCRP helper class for paper options
 // Copyright (c) 2006-2020 Eddie Kohler; see LICENSE.
 
+global $ConfSitePATH, $Opt;
+if (isset($Opt["iacrType"])) {
+  require_once("$ConfSitePATH/iacr/includes/papertable.php");
+}
+
 class PaperValue {
     public $prow;
     public $id;
@@ -999,6 +1004,10 @@ class CheckboxPaperOption extends PaperOption {
         $cb = Ht::checkbox($this->formid, 1, !!$reqov->value, [
             "id" => $this->readable_formid(), "data-default-checked" => !!$ov->value
         ]);
+        // For IACR options, we put out a button on the final versions.
+        if ($this->conf->opt["iacrType"] && iacr_paper_option($this)) {
+           echo_iacr_button($this->id, $pt->conf, $pt->prow->paperId);
+        }
         $pt->echo_editable_option_papt($this,
             '<span class="checkc">' . $cb . '</span>' . $pt->edit_title_html($this),
             ["for" => "checkbox", "tclass" => "ui js-click-child"]);

--- a/src/papertable.php
+++ b/src/papertable.php
@@ -670,6 +670,7 @@ class PaperTable {
         }
         if (isset($docx->conf->opt['iacrType']) && $dtype == DTYPE_FINAL) {
           // We don't show the final upload button.
+          // We may need a closing </div> (I can't tell).
           return;
         }
         $inputid = $dtype > 0 ? "opt" . $dtype : "paperUpload";

--- a/src/papertable.php
+++ b/src/papertable.php
@@ -5,7 +5,7 @@
 ///////////// Added for IACR functionality ////////////
 global $ConfSitePATH, $Opt;
 if (isset($Opt["iacrType"])) {
-  include "$ConfSitePATH/iacr/includes/papertable.php";
+  require_once("$ConfSitePATH/iacr/includes/papertable.php");
 }
 ///////////////////////////////////////////////////////
 
@@ -668,10 +668,8 @@ class PaperTable {
                 || ($dtype == DTYPE_FINAL) !== $this->canUploadFinal)
                 return;
         }
-        if (isset($docx->conf->opt["iacrType"]) && $dtype === DTYPE_FINAL) {
-          global $Me;
-          echo_iacr_final_upload($docx, $this->prow, $Me->email);
-          echo "</div>";
+        if (isset($docx->conf->opt['iacrType']) && $dtype == DTYPE_FINAL) {
+          // We don't show the final upload button.
           return;
         }
         $inputid = $dtype > 0 ? "opt" . $dtype : "paperUpload";
@@ -1548,9 +1546,6 @@ class PaperTable {
         global $Opt;
         if (!$heading) {
             $heading = $this->edit_title_html($o);
-        }
-        if ($o !== null && $o->readable_formid() === "iacr-copyright-agreement") {
-            echo_iacrcopyright_button($this->prow->paperId, $Opt["shortName"]);
         }
         $this->echo_editable_papt($o->formid, $heading, $rest, $o);
         $this->echo_field_hint($o);

--- a/src/settings/s_options.php
+++ b/src/settings/s_options.php
@@ -155,8 +155,13 @@ class Options_SettingRenderer {
         echo '<div class="', join(" ", $this->option_classes),
             '"><a href="" class="q ui settings-field-folder"><span class="expander"><span class="in0 fx2">▼</span></span></a>';
 
+        // For IACR options, we make the name readonly.
+        $extras = ["placeholder" => "Field name", "size" => 50, "id" => "optn_$xpos", "style" => "font-weight:bold", "class" => "need-tooltip", "data-tooltip-info" => "settings-option", "data-tooltip-type" => "focus", "aria-label" => "Field name"];
+        if (iacr_paper_option($o)) {
+          $extras['readonly'] = true;
+        }
         echo '<div class="', $sv->control_class("optn_$xpos", "f-i"), '">',
-            Ht::entry("optn_$xpos", $o->name, $sv->sjs("optn_$xpos", ["placeholder" => "Field name", "size" => 50, "id" => "optn_$xpos", "style" => "font-weight:bold", "class" => "need-tooltip", "data-tooltip-info" => "settings-option", "data-tooltip-type" => "focus", "aria-label" => "Field name"])),
+            Ht::entry("optn_$xpos", $o->name, $sv->sjs("optn_$xpos", $extras)),
             $sv->render_messages_at("optn_$xpos"),
             Ht::hidden("optid_$xpos", $o->id ? : "new", ["class" => "settings-opt-id"]),
             Ht::hidden("optfp_$xpos", $xpos, ["class" => "settings-opt-fp", "data-default-value" => $xpos]),
@@ -183,9 +188,13 @@ class Options_SettingRenderer {
             '<span class="btnbox">',
             Ht::button(Icons::ui_movearrow(0), ["class" => "btn-licon ui js-settings-option-move moveup need-tooltip", "aria-label" => "Move up in display order"]),
             Ht::button(Icons::ui_movearrow(2), ["class" => "btn-licon ui js-settings-option-move movedown need-tooltip", "aria-label" => "Move down in display order"]),
-            '</span>',
-            Ht::button(Icons::ui_trash(), ["class" => "btn-licon ui js-settings-option-move delete need-tooltip", "aria-label" => "Delete", "data-option-exists" => get($this->have_options, $o->id)]),
-            "</div></div>\n";
+            '</span>';
+        if (!isset($sv->conf->opt['iacrType']) ||
+            !iacr_required_paper_option($o->id)) {
+              // We only show the delete button for non-required options.
+              echo Ht::button(Icons::ui_trash(), ["class" => "btn-licon ui js-settings-option-move delete need-tooltip", "aria-label" => "Delete", "data-option-exists" => get($this->have_options, $o->id)]);
+            }
+            echo "</div></div>\n";
 
         echo '</div>';
     }


### PR DESCRIPTION
This will almost certainly create conflicts when we merge from upstream, but that's unavoidable. HotCRP isn't really meant to be extensible and there is constant churn on the codebase. 

This changes behavior for four paper options required, namely
5. IACR copyright
6. final version upload
7. slides upload
8. video upload
It modifies how they are shown in the chair view and the author view. The chair may not change the name of the IACR options, and may not delete 5,6,7. They may delete #8. The author sees checkbox options that may only be changed by clicking on the button and completing the action on the target. The copyright and final paper are updated.
TODO: make the slides upload and video upload be recorded by an API callback from the submit server.
TODO: update create_conf.py to create these options correctly. There will be a separate pull request for this, but kdev already has the options.