### PR TITLE
Add contactTags field for non-chair.

### DIFF
--- a/src/userstatus.php
+++ b/src/userstatus.php
@@ -1524,7 +1524,10 @@ topics. We use this information to help match papers to reviewers.</p>',
                 "</div>
   <p class=\"f-h\">Example: “heavy”. Separate tags by spaces; the “pc” tag is set automatically.<br /><strong>Tip:</strong>&nbsp;Use <a href=\"", $us->conf->hoturl("settings", "group=tags"), "\">tag colors</a> to highlight subgroups in review lists.</p>\n";
         } else {
-            echo $itags, "<p class=\"f-h\">Tags represent PC subgroups and are set by administrators.</p>\n";
+            echo '<div class="', $us->control_class("contactTags", "f-i"), '" readonly>',
+                Ht::entry("contactTags", $qreq->contactTags ?? $itags, ["size" => 60, "data-default-value" => $itags]),
+                "</div>
+  <p class=\"f-h\">Tags represent PC subgroups and are set by administrators.</p>\n";
         }
     }
 


### PR DESCRIPTION
The "Fetch recent coauthors" function seems to be broken (it didn't work for me as a pc member fot tosc2022_2).

As far as I can tell, the issue is at https://github.com/IACR/hotcrp/blob/541762eb76b6962ae438fd8cfa7c776ce177f99e/iacr/collaborators.inc#L22

This line assumes that there is an `input` field named `contactTags`, but this is only the case for chairs.  This patch adds the field for all users, and should fix the "Fetch recent coauthors" function.

Note: I haven't tested the patch, and I don't know PHP, so there might be a stupid mistake in the patch :-)